### PR TITLE
Remove equals from EquivalenceClass and require subtypes to implement it

### DIFF
--- a/src/main/scala/core/EquivalenceClass.scala
+++ b/src/main/scala/core/EquivalenceClass.scala
@@ -23,26 +23,6 @@ trait EquivalenceClass[A] {
     */
   def contains(a: A): Boolean = relation.areEquivalent(representative, a)
 
-  /**
-    * Determines whether the EquivalenceClasses are equal.
-    *
-    * This is done by checking whether each EquivalenceClass contains the representative element of the other.  Note
-    * that this check is somewhat unsafe since it does not check whether the two [[EquivalenceRelation]]s are the same.
-    * This shortcoming is due to the fact that it would require equality checks for functions.  This shortcoming is
-    * overcome in certain subtypes such as [[ResidueClass]].
-    * @param eq
-    * @return
-    */
-  def ==(eq: EquivalenceClass[A]): Boolean = this.contains(eq.representative) && eq.contains(this.representative)
-
-  def !=(eq: EquivalenceClass[A]): Boolean = !(this == eq)
-
-  //TODO: Is this implementation really correct?
-  override def equals(obj: scala.Any): Boolean = obj match {
-    case eq: EquivalenceClass[A] => this == eq
-    case _ => false
-  }
-
 }
 
 /**

--- a/src/main/scala/core/RationalExpression.scala
+++ b/src/main/scala/core/RationalExpression.scala
@@ -2,6 +2,8 @@ package core
 
 import algebra.ring.{CommutativeRing, EuclideanRing, Field}
 
+import scala.util.{Failure, Success, Try}
+
 /**
   * A quotient of elements from a EuclideanRing.
   *
@@ -50,6 +52,14 @@ trait RationalExpression[A] extends EquivalenceClass[(A, A)] {
       val (num2, denom2) = y
 
       domain.times(num1, denom2) == domain.times(denom1, num2)
+    }
+  }
+
+  override def equals(obj: scala.Any): Boolean = {
+
+    Try(obj.asInstanceOf[RationalExpression[A]]) match {
+      case Success(re) => this.relation.areEquivalent(this.representative, re.representative)
+      case Failure(throwable) => false
     }
   }
 }

--- a/src/main/scala/core/ResidueClass.scala
+++ b/src/main/scala/core/ResidueClass.scala
@@ -1,8 +1,8 @@
 package core
 
 import algebra.ring.{CommutativeRing, EuclideanRing, Field}
+import scala.util.{Try, Success, Failure}
 
-//TODO: override equals since we can do "function equality" by inspecting the modulus.
 /**
   * An equivalence class of elements from a EuclideanRing produced by modding out by an element.
   *
@@ -31,6 +31,14 @@ trait ResidueClass[A] extends EquivalenceClass[A] {
   def /(other: ResidueClass[A])(implicit field: Field[ResidueClass[A]]): ResidueClass[A] = field.div(this, other)
 
   def inv(implicit field: Field[ResidueClass[A]]): ResidueClass[A] = field.div(field.one, this)
+
+  override def equals(obj: scala.Any): Boolean = {
+
+    Try(obj.asInstanceOf[ResidueClass[A]]) match {
+      case Success(rc) => this.modulus == rc.modulus && this.contains(rc.representative)
+      case Failure(throwable) => false
+    }
+  }
 
 }
 

--- a/src/test/scala/core/EquivalenceClassTest.scala
+++ b/src/test/scala/core/EquivalenceClassTest.scala
@@ -13,26 +13,6 @@ class EquivalenceClassTest extends FunSuite with Matchers {
   val classForOne = EquivalenceClass(1, relation)
   val classForThree = EquivalenceClass(3, relation)
 
-  test("Equivalence classes are equal when their representatives evaluate to the same value under the equivalence relation") {
-
-    classForZero == classForTwo should be (true)
-    classForZero == classForFour should be (true)
-
-    //You can also write it this way
-    classForZero should be (classForTwo)
-    classForTwo should be (classForFour)
-  }
-
-  test("Equivalence classes are not equal when their representatives do not evaluate to the same value under the equivalence relation") {
-
-    classForZero != classForOne should be (true)
-    classForZero != classForThree should be (true)
-
-    //You can also write it this way
-    classForZero should not be classForOne
-    classForZero should not be classForThree
-  }
-
   test("You can ask an equivalence class if it contains an element") {
 
     classForZero.contains(6) should be (true)

--- a/src/test/scala/core/RationalExpressionTest.scala
+++ b/src/test/scala/core/RationalExpressionTest.scala
@@ -19,6 +19,11 @@ class RationalExpressionTest extends FunSuite with Matchers {
     RationalExpression(2, 3) != RationalExpression(4, 6) should be (false)
   }
 
+  test("Equality checks for compatible types") {
+
+    RationalExpression(2, 1) != 2 should be (true)
+  }
+
   test("Use === for testing representational equality") {
 
     RationalExpression(2, 3) === RationalExpression(2, 3) should be (true)

--- a/src/test/scala/core/ResidueClassTest.scala
+++ b/src/test/scala/core/ResidueClassTest.scala
@@ -1,0 +1,47 @@
+package core
+
+import org.scalatest.{FunSuite, Matchers}
+import IntegerModding._
+import ModuloOperations._
+
+class ResidueClassTest extends FunSuite with Matchers {
+
+  test("Residue class equality holds as expected") {
+
+    implicit def intsMod4 = integers modulo_r 4
+    def classOf = intToResidueClass(4)
+
+    classOf(2) == classOf(2) should be (true)
+    classOf(2) == classOf(6) should be (true)
+    classOf(2) == classOf(-2) should be (true)
+  }
+
+  test("Residue class equality does not hold as expected") {
+
+    implicit def intsMod4 = integers modulo_r 4
+    def classOf = intToResidueClass(4)
+
+    classOf(2) != classOf(3) should be (true)
+    classOf(7) != classOf(0) should be (true)
+  }
+
+  test("Residue classes of different moduli cannot be equal") {
+
+    def intsMod4 = integers modulo_r 4
+    def mod4 = intToResidueClass(4)
+
+    def intsMod6 = integers modulo_r 6
+    def mod6 = intToResidueClass(6)
+
+    mod4(2) != mod6(2) should be (true)
+  }
+
+  test("Residue class equality takes types into account") {
+
+    implicit def intsMod4 = integers modulo_r 4
+    def classOf = intToResidueClass(4)
+
+    classOf(2) != 2
+  }
+
+}


### PR DESCRIPTION
ResidueClass and RationalExpression have their own equals methods